### PR TITLE
docs: fix signature verification code

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ def lambda_handler(event, context):
 
     verify_key = VerifyKey(bytes.fromhex(PUBLIC_KEY))
 
-    message = timestamp + json.dumps(body, separators=(',', ':'))
+    message = timestamp + event['body']
     
     try:
       verify_key.verify(message.encode(), signature=bytes.fromhex(signature))


### PR DESCRIPTION
Setting the Endpoint URL works just fine with the given code. However, I found that testing out the slash commands, the signature verification would fail. I have provided an alternative and cleaner method of verifying the signature.