### PR TITLE
Fix issue with data formatting for Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ def command_handler(body):
   if command == 'bleb':
     return {
       'statusCode': 200,
+      'headers' : {'Content-Type': 'application/json'},
       'body': json.dumps({
         'type': 4,
         'data': {


### PR DESCRIPTION
Lambda will often default it to text/plain even if you're returning json-formattable data, This makes sure the data will be formatted correctly when sent to discord.